### PR TITLE
Add packaging metadata for PyPI distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 *.pyc
 .env
 outputs/
+dist/
+build/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ personas and generating concept images through the OpenRouter image API.
 - Preview prompts without generating images via `--dry-run` mode.
 - Supply one or more reference images or URLs to steer the generation results.
 
+## Installation
+
+Install the published package from PyPI:
+
+```bash
+pip install mony
+```
+
 ## Prerequisites
 
 1. Create a Python 3.10+ virtual environment and install dependencies:

--- a/mony/__init__.py
+++ b/mony/__init__.py
@@ -1,3 +1,7 @@
 """Mony package for generating UI concept images via OpenRouter."""
 
-__all__ = ["cli"]
+from . import cli
+
+__all__ = ["cli", "__version__"]
+
+__version__ = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mony"
+version = "0.1.0"
+description = "CLI for generating UI concept images via OpenRouter"
+readme = "README.md"
+authors = [{ name = "Mony Maintainers" }]
+license = "MIT"
+requires-python = ">=3.10"
+dependencies = [
+    "requests",
+]
+
+[project.urls]
+Homepage = "https://example.com/mony"
+
+[project.scripts]
+mony = "mony.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["mony"]


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` with setuptools configuration, dependencies, and console entry point
- expose the package version via `mony.__init__` and document PyPI installation in the README
- ignore build artifacts generated while creating source and wheel distributions

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68f0e8f14c148333b563f72c433f7e94